### PR TITLE
fix: 修复英文版/双语版首页目录链接 404

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -319,20 +319,21 @@
 
       function fixMarkdownLinks() {
         const contentArea = document.querySelector('.content');
-        if (contentArea) {
-          const links = contentArea.querySelectorAll('a[href*=".md"]');
-          links.forEach(function(link) {
-            let href = link.getAttribute('href');
-            if (href && !href.startsWith('http') && href.includes('.md')) {
-              href = href.replace(/\.md$/, '');
-              href = decodeURIComponent(href);
-              if (!href.startsWith('/')) {
-                href = '/' + href;
-              }
-              link.setAttribute('href', '{{ site.baseurl }}' + href);
-            }
-          });
-        }
+        if (!contentArea) return;
+        const links = contentArea.querySelectorAll('a[href*=".md"]');
+        links.forEach(function(link) {
+          const href = link.getAttribute('href');
+          if (!href || !href.includes('.md')) return;
+          if (/^([a-z]+:|#|\/\/)/i.test(href)) return;
+          try {
+            const resolved = new URL(href, window.location.href);
+            if (resolved.origin !== window.location.origin) return;
+            resolved.pathname = resolved.pathname.replace(/\.md$/i, '');
+            link.setAttribute('href', resolved.pathname + resolved.search + resolved.hash);
+          } catch (e) {
+            // Leave the link untouched if URL parsing fails.
+          }
+        });
       }
       
       fixMarkdownLinks();


### PR DESCRIPTION
`original/README.md` 与 `bilingual/index.md` 的目录使用相对路径 `Chapter%201_%20Prompt%20Chaining.md`，jekyll-relative-links 无法识别 URL 编码路径、未转成站点 URL，需由前端 `fixMarkdownLinks()` 处理。

旧实现把所有非绝对链接直接拼上 `/`，丢失了当前目录上下文，
导致 `/original/`、`/bilingual/` 首页的目录全部跳到 `/Chapter 1_ ...` （404），而非 `/original/Chapter 1_ ...`。

改用 `new URL(href, window.location.href)` 按当前页面 URL 解析相对 路径，自然支持 `../`、绝对路径、外链、`#` 锚点、查询串与 fragment；
去掉多余的 `decodeURIComponent`（浏览器会自行编码导航 URL）。

中文根 `/` 的链接显式带 `chapters/` 前缀，新旧实现等价；
双语布局继承 default，同时修复。

验证：本地 `jekyll build` 后用同名逻辑跑在 `_site/original/index.html` 内容区全部 33 个 `.md` href 上，30 个章节/附录链接全部解析为
`/original/<chapter>`，目标 URL 在 `_site` 中实际存在；
余下 3 个 `../*.md` 指向 `_config.yml` exclude 中的文件，

Jekyll 不生成对应页面，修复前后均 404，与本次 bug 无关。