### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ agentic-design-patterns/
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=xindoo/agentic-design-patterns&type=date&legend=top-left)](https://github.com/xindoo/agentic-design-patterns)
+[![Star History Chart](https://star-history.dera.page/svg?repos=xindoo/agentic-design-patterns&type=date&legend=top-left)](https://github.com/xindoo/agentic-design-patterns)
 
 ## 📄 许可证
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已损坏，原因是 GitHub Stargazer API 的限制。本次修改将其切换至一个无需 API Token 的新数据源，从而恢复图表的正常显示。